### PR TITLE
Jax

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,3 +58,9 @@ For people developing on the environment, style-checking and static type-checkin
 pip install pre-commit
 pre-commit install
 ```
+
+## Usage
+The general design flow will follow something like below:
+1. Define a `System` class. This involves writing the initialization code (i.e. parameterizing the system) and then defining the dynamics. When the system is defined, you must use Jax arrays so that the linearized form can be computed using autodifferentiation (see `quad.py` or `segway.py` for examples).
+2. Define a `Controller` class corresponding to the system. For example, see `slmpc_quad_ctrl.py`, which simply defines the desired state/input constraints as well as specifying an input `u_bar` around which to linearize for the linearization-based model predictive controller. This makes heavy use of the comprehensive `SLMPC` abstract class.
+3. Write a script that demonstrates the controller on the system and uses the `Simulator` class. See `ex_slmpc_quad.py` for an example.

--- a/dyn_sim/ctrl/mpc.py
+++ b/dyn_sim/ctrl/mpc.py
@@ -178,9 +178,12 @@ class SLMPC(FullMemoryBWLC):
         feq = self._sys.dyn(t, x, ubar)  # offset for Taylor expansion
 
         # discrete-time linearized dynamics
-        Ak = np.array(np.eye(n) + h * A)  # cast jnp to onp before passing to grb
-        Bk = np.array(h * B)
-        Ck = np.array(-h * (A @ x + B @ ubar - feq))
+        # Ak = np.array(np.eye(n) + h * A)  # cast jnp to onp before passing to grb
+        # Bk = np.array(h * B)
+        # Ck = np.array(-h * (A @ x + B @ ubar - feq))
+        Ak = np.eye(n) + h * A
+        Bk = h * B
+        Ck = -h * (A @ x + B @ ubar - feq)
 
         # constructing dynamics constraints
         x_var = self._gp_xvar

--- a/dyn_sim/ctrl/mpc.py
+++ b/dyn_sim/ctrl/mpc.py
@@ -173,14 +173,14 @@ class SLMPC(FullMemoryBWLC):
 
         # continuous-time linearized dynamics
         ubar = self._compute_ubar(x)
-        A = self._sys.A(x, ubar)
-        B = self._sys.B(x, ubar)
+        A = self._sys.A(t, x, ubar)
+        B = self._sys.B(t, x, ubar)
         feq = self._sys.dyn(t, x, ubar)  # offset for Taylor expansion
 
         # discrete-time linearized dynamics
-        Ak = np.eye(n) + h * A
-        Bk = h * B
-        Ck = -h * (A @ x + B @ ubar - feq)
+        Ak = np.array(np.eye(n) + h * A)  # cast jnp to onp before passing to grb
+        Bk = np.array(h * B)
+        Ck = np.array(-h * (A @ x + B @ ubar - feq))
 
         # constructing dynamics constraints
         x_var = self._gp_xvar

--- a/dyn_sim/ctrl/mpc.py
+++ b/dyn_sim/ctrl/mpc.py
@@ -178,9 +178,6 @@ class SLMPC(FullMemoryBWLC):
         feq = self._sys.dyn(t, x, ubar)  # offset for Taylor expansion
 
         # discrete-time linearized dynamics
-        # Ak = np.array(np.eye(n) + h * A)  # cast jnp to onp before passing to grb
-        # Bk = np.array(h * B)
-        # Ck = np.array(-h * (A @ x + B @ ubar - feq))
         Ak = np.eye(n) + h * A
         Bk = h * B
         Ck = -h * (A @ x + B @ ubar - feq)

--- a/dyn_sim/ctrl/spatial/quad/pd_quad_ctrl.py
+++ b/dyn_sim/ctrl/spatial/quad/pd_quad_ctrl.py
@@ -189,6 +189,6 @@ class PDQuadController(Controller):
         wsq = self._rebalance(wsq)
 
         # conversion to virtual inputs for simulation
-        i = self._sys.V @ wsq
+        i = self._sys.V() @ wsq
 
         return i

--- a/dyn_sim/ctrl/spatial/quad/slmpc_quad_ctrl.py
+++ b/dyn_sim/ctrl/spatial/quad/slmpc_quad_ctrl.py
@@ -115,4 +115,6 @@ class SLMPCQuadController(SLMPC):
         for i in range(N):
             ui = u_var[i, :]
             self._gpmodel.addConstr(ui[0] >= 0)  # thrust
-            self._gpmodel.addConstr(self._sys.invV @ ui >= 1e-3)  # rotor speed
+            self._gpmodel.addConstr(
+                np.array(self._sys.invV) @ ui >= 1e-3
+            )  # rotor speed

--- a/dyn_sim/ctrl/spatial/quad/slmpc_quad_ctrl.py
+++ b/dyn_sim/ctrl/spatial/quad/slmpc_quad_ctrl.py
@@ -115,6 +115,4 @@ class SLMPCQuadController(SLMPC):
         for i in range(N):
             ui = u_var[i, :]
             self._gpmodel.addConstr(ui[0] >= 0)  # thrust
-            self._gpmodel.addConstr(
-                np.array(self._sys.invV) @ ui >= 1e-3
-            )  # rotor speed
+            self._gpmodel.addConstr(self._sys.invV() @ ui >= 1e-3)  # rotor speed

--- a/dyn_sim/sys/spatial/quad.py
+++ b/dyn_sim/sys/spatial/quad.py
@@ -111,6 +111,11 @@ class Quadrotor(CtrlAffineSystem):
         are converted (in an invertible way) using _V.
 
         u = V @ wsq
+
+        Returns
+        -------
+        _V : jnp.ndarray, shape=(4, 4)
+            See above.
         """
         kf = self._kf
         km = self._km
@@ -132,6 +137,11 @@ class Quadrotor(CtrlAffineSystem):
         """Matrix converting virtual forces/moments to squared rotor speeds.
 
         wsq = invV @ u
+
+        Returns
+        -------
+        _invV : jnp.ndarray, shape=(4, 4)
+            Inverse of V. See above.
         """
         kf = self._kf
         km = self._km
@@ -356,7 +366,7 @@ class Quadrotor(CtrlAffineSystem):
         t: float,
         s: np.ndarray,
         u: np.ndarray,
-        d: np.ndarray = jnp.zeros(6),
+        d: np.ndarray = np.zeros(6),
     ) -> jnp.ndarray:
         """Quadrotor dynamics function.
 
@@ -368,7 +378,7 @@ class Quadrotor(CtrlAffineSystem):
             State of the quadrotor.
         u : np.ndarray, shape=(4,)
             Virtual input of the quadrotor.
-        d : np.ndarray, shape=(6,), default=jnp.zeros(6)
+        d : np.ndarray, shape=(6,), default=np.zeros(6)
             Disturbances to the quadrotor.
 
         Returns

--- a/dyn_sim/sys/spatial/quad.py
+++ b/dyn_sim/sys/spatial/quad.py
@@ -306,13 +306,9 @@ class Quadrotor(CtrlAffineSystem):
 
         # accelerations
         ddo_b = jnp.zeros((3, 4))
-        # ddo_b[2, 0] = 1.0 / m  # jax debug
         ddo_b = ddo_b.at[2, 0].set(1.0 / m)
 
         ddalpha_b = jnp.zeros((3, 4))
-        # ddalpha_b[0, 1] = 1.0 / Ix
-        # ddalpha_b[1, 2] = 1.0 / Iy
-        # ddalpha_b[2, 3] = 1.0 / Iz
         ddalpha_b = ddalpha_b.at[0, 1].set(1.0 / Ix)
         ddalpha_b = ddalpha_b.at[1, 2].set(1.0 / Iy)
         ddalpha_b = ddalpha_b.at[2, 3].set(1.0 / Iz)
@@ -402,14 +398,10 @@ class Quadrotor(CtrlAffineSystem):
             wsq = self.invV(np_out=False) @ u
             assert all(wsq >= 0.0)
             w = jnp.sqrt(wsq)
-            # w[0] *= -1  # debug jax
-            # w[2] *= -1
             w = w.at[0].set(w[0] * -1)
             w = w.at[2].set(w[2] * -1)
             Omega = jnp.sum(w)  # net prop speeds
 
-            # ds_gyro[9] = -Jtp * q * Omega / Ix
-            # ds_gyro[10] = Jtp * p * Omega / Iy
             ds_gyro = ds_gyro.at[9].set(-Jtp * q * Omega / Ix)
             ds_gyro = ds_gyro.at[10].set(Jtp * p * Omega / Iy)
 
@@ -433,7 +425,7 @@ class Quadrotor(CtrlAffineSystem):
         l = self._l
         o = s[0:3]  # x, y, z
         alpha = s[3:6]  # phi, theta, psi
-        Rwb = np.array(self.Rwb(alpha))
+        Rwb = self.Rwb(alpha)
 
         # rotor base locations on frame in inertial frame
         r1 = o + Rwb @ np.array([l, 0.0, 0.0])

--- a/dyn_sim/sys/spatial/quad.py
+++ b/dyn_sim/sys/spatial/quad.py
@@ -103,7 +103,7 @@ class Quadrotor(CtrlAffineSystem):
         self._Jtp = Jtp
 
     @jax_func
-    def V(self) -> np.ndarray:
+    def V(self) -> jnp.ndarray:
         """Matrix converting squared rotor speeds to virtual forces/moments.
 
         Controller design occurs using virtual force/torque inputs, but true
@@ -128,7 +128,7 @@ class Quadrotor(CtrlAffineSystem):
         return _V
 
     @jax_func
-    def invV(self) -> np.ndarray:
+    def invV(self) -> jnp.ndarray:
         """Matrix converting virtual forces/moments to squared rotor speeds.
 
         wsq = invV @ u
@@ -152,7 +152,7 @@ class Quadrotor(CtrlAffineSystem):
         return _invV
 
     @jax_func
-    def Rwb(self, alpha: np.ndarray) -> np.ndarray:
+    def Rwb(self, alpha: np.ndarray) -> jnp.ndarray:
         """Rotation matrix from BODY to WORLD frame (ZYX Euler).
 
         Parameters
@@ -162,7 +162,7 @@ class Quadrotor(CtrlAffineSystem):
 
         Returns
         -------
-        R : np.ndarray, shape=(3, 3)
+        R : jnp.ndarray, shape=(3, 3)
             Rotation matrix from BODY to WORLD frame.
         """
         assert alpha.shape == (3,)
@@ -194,7 +194,7 @@ class Quadrotor(CtrlAffineSystem):
         return R
 
     @jax_func
-    def Twb(self, alpha: np.ndarray) -> np.ndarray:
+    def Twb(self, alpha: np.ndarray) -> jnp.ndarray:
         """Angular velocity transformation matrix from BODY to WORLD frame (ZYX Euler).
 
         Parameters
@@ -204,7 +204,7 @@ class Quadrotor(CtrlAffineSystem):
 
         Returns
         -------
-        T : np.ndarray, shape=(3, 3)
+        T : jnp.ndarray, shape=(3, 3)
             Angular velocity transformation matrix from BODY to WORLD frame.
         """
         assert alpha.shape == (3,)
@@ -226,7 +226,7 @@ class Quadrotor(CtrlAffineSystem):
         return T
 
     @jax_func
-    def fdyn(self, t: float, s: np.ndarray) -> np.ndarray:
+    def fdyn(self, t: float, s: np.ndarray) -> jnp.ndarray:
         """Quadrotor autonomous dynamics.
 
         Parameters
@@ -238,7 +238,7 @@ class Quadrotor(CtrlAffineSystem):
 
         Returns
         -------
-        _fdyn : np.ndarray, shape=(12,)
+        _fdyn : jnp.ndarray, shape=(12,)
             Time derivatives of states from autonomous dynamics.
         """
         assert s.shape == (12,)
@@ -283,7 +283,7 @@ class Quadrotor(CtrlAffineSystem):
         return _fdyn
 
     @jax_func
-    def gdyn(self, t: float, s: np.ndarray) -> np.ndarray:
+    def gdyn(self, t: float, s: np.ndarray) -> jnp.ndarray:
         """Quadrotor control dynamics.
 
         Parameters
@@ -295,7 +295,7 @@ class Quadrotor(CtrlAffineSystem):
 
         Returns
         -------
-        _gdyn : np.ndarray, shape=(12, 4)
+        _gdyn : jnp.ndarray, shape=(12, 4)
             Matrix representing affine control dynamics.
         """
         assert s.shape == (12,)
@@ -317,7 +317,7 @@ class Quadrotor(CtrlAffineSystem):
         return _gdyn
 
     @jax_func
-    def wdyn(self, t: float, d: np.ndarray) -> np.ndarray:
+    def wdyn(self, t: float, d: np.ndarray) -> jnp.ndarray:
         """Quadrotor disturbance dynamics in BODY frame.
 
         Global disturbances must first be rotated into the body frame!
@@ -331,7 +331,7 @@ class Quadrotor(CtrlAffineSystem):
 
         Returns
         -------
-        w : np.ndarray, shape=(12,)
+        w : jnp.ndarray, shape=(12,)
             Time derivatives of states from disturbance dynamics
         """
         assert d.shape == (6,)
@@ -357,7 +357,7 @@ class Quadrotor(CtrlAffineSystem):
         s: np.ndarray,
         u: np.ndarray,
         d: np.ndarray = jnp.zeros(6),
-    ) -> np.ndarray:
+    ) -> jnp.ndarray:
         """Quadrotor dynamics function.
 
         Parameters
@@ -373,7 +373,7 @@ class Quadrotor(CtrlAffineSystem):
 
         Returns
         -------
-        ds : np.ndarray, shape=(12,)
+        ds : jnp.ndarray, shape=(12,)
             Time derivative of the states.
         """
         assert s.shape == (12,)

--- a/dyn_sim/sys/spatial/quad.py
+++ b/dyn_sim/sys/spatial/quad.py
@@ -396,7 +396,6 @@ class Quadrotor(CtrlAffineSystem):
             q = s[10]
 
             wsq = self.invV(np_out=False) @ u
-            assert jnp.all(wsq >= 0.0)
             w = jnp.sqrt(wsq)
             w = w.at[0].set(w[0] * -1)
             w = w.at[2].set(w[2] * -1)

--- a/dyn_sim/sys/spatial/quad.py
+++ b/dyn_sim/sys/spatial/quad.py
@@ -396,7 +396,7 @@ class Quadrotor(CtrlAffineSystem):
             q = s[10]
 
             wsq = self.invV(np_out=False) @ u
-            assert all(wsq >= 0.0)
+            assert jnp.all(wsq >= 0.0)
             w = jnp.sqrt(wsq)
             w = w.at[0].set(w[0] * -1)
             w = w.at[2].set(w[2] * -1)

--- a/dyn_sim/sys/sys_core.py
+++ b/dyn_sim/sys/sys_core.py
@@ -1,6 +1,7 @@
 from abc import ABC, ABCMeta, abstractmethod
 from typing import Optional, Union
 
+import jax.numpy as jnp
 import numpy as np
 from jax import jacobian
 from matplotlib.axes import Axes
@@ -35,7 +36,7 @@ class System(ABC):
 
     @abstractmethod
     @jax_func
-    def dyn(self, t: float, x: np.ndarray, u: np.ndarray) -> np.ndarray:
+    def dyn(self, t: float, x: np.ndarray, u: np.ndarray) -> jnp.ndarray:
         """Dynamics of the system.
 
         Parameters
@@ -49,12 +50,12 @@ class System(ABC):
 
         Returns
         -------
-        dx : np.ndarray, shape=(n,)
+        dx : jnp.ndarray, shape=(n,)
             Time derivative of current state.
         """
 
     @jax_func
-    def A(self, t: float, x: np.ndarray, u: np.ndarray) -> np.ndarray:
+    def A(self, t: float, x: np.ndarray, u: np.ndarray) -> jnp.ndarray:
         """Linearized autonomous dynamics about (x, u).
 
         Parameters
@@ -68,15 +69,15 @@ class System(ABC):
 
         Returns
         -------
-        _A : np.ndarray, shape=(n, n)
+        _A : jnp.ndarray, shape=(n, n)
             Linearized autonomous dynamics about (x, u).
         """
-        dyn_jnp = lambda x, u: self.dyn(t, x, u, np_out=False)
+        dyn_jnp = lambda _x, _u: self.dyn(t, _x, _u, np_out=False)
         _A = jacobian(dyn_jnp, argnums=0)(x, u)
         return _A
 
     @jax_func
-    def B(self, t: float, x: np.ndarray, u: np.ndarray) -> np.ndarray:
+    def B(self, t: float, x: np.ndarray, u: np.ndarray) -> jnp.ndarray:
         """Linearized control dynamics about (x, u).
 
         Parameters
@@ -90,10 +91,10 @@ class System(ABC):
 
         Returns
         -------
-        _B : np.ndarray, shape=(n, m)
+        _B : jnp.ndarray, shape=(n, m)
             Linearized control dynamics about (x, u).
         """
-        dyn_jnp = lambda x, u: self.dyn(t, x, u, np_out=False)
+        dyn_jnp = lambda _x, _u: self.dyn(t, _x, _u, np_out=False)
         _B = jacobian(dyn_jnp, argnums=1)(x, u)
         return _B
 
@@ -132,7 +133,7 @@ class CtrlAffineSystem(System, metaclass=ABCMeta):
 
     @abstractmethod
     @jax_func
-    def fdyn(self, t: float, x: np.ndarray) -> np.ndarray:
+    def fdyn(self, t: float, x: np.ndarray) -> jnp.ndarray:
         """Drift of the system.
 
         Parameters
@@ -144,13 +145,13 @@ class CtrlAffineSystem(System, metaclass=ABCMeta):
 
         Returns
         -------
-        f_val : np.ndarray, shape=(n,)
+        f_val : jnp.ndarray, shape=(n,)
             Value of the drift of the system.
         """
 
     @abstractmethod
     @jax_func
-    def gdyn(self, t: float, x: np.ndarray) -> np.ndarray:
+    def gdyn(self, t: float, x: np.ndarray) -> jnp.ndarray:
         """Actuation matrix.
 
         Parameters
@@ -162,12 +163,12 @@ class CtrlAffineSystem(System, metaclass=ABCMeta):
 
         Returns
         -------
-        g_val : np.ndarray, shape=(n, m)
+        g_val : jnp.ndarray, shape=(n, m)
             Value of the actuation matrix of the system.
         """
 
     @jax_func
-    def dyn(self, t: float, x: np.ndarray, u: np.ndarray) -> np.ndarray:
+    def dyn(self, t: float, x: np.ndarray, u: np.ndarray) -> jnp.ndarray:
         """See parent docstring."""
         assert x.shape == (self._n,)
         assert u.shape == (self._m,)

--- a/dyn_sim/sys/sys_core.py
+++ b/dyn_sim/sys/sys_core.py
@@ -7,6 +7,8 @@ from jax import jacobian, jit
 from matplotlib.axes import Axes
 from mpl_toolkits.mplot3d.axes3d import Axes3D
 
+from dyn_sim.util.jax_utils import jax_func
+
 
 class System(ABC):
     """Abstract class for dynamical systems."""
@@ -52,7 +54,8 @@ class System(ABC):
             Time derivative of current state.
         """
 
-    @partial(jit, static_argnums=(0,))
+    # @partial(jit, static_argnums=(0,))
+    @jax_func
     def A(self, t: float, x: np.ndarray, u: np.ndarray) -> np.ndarray:
         """Linearized autonomous dynamics about (x, u).
 
@@ -74,7 +77,6 @@ class System(ABC):
         _A = jacobian(dyn_jnp, argnums=0)(x, u)
         return _A
 
-    @property
     @partial(jit, static_argnums=(0,))
     def B(self, t: float, x: np.ndarray, u: np.ndarray) -> np.ndarray:
         """Linearized control dynamics about (x, u).

--- a/dyn_sim/sys/sys_core.py
+++ b/dyn_sim/sys/sys_core.py
@@ -70,10 +70,11 @@ class System(ABC):
         _A : np.ndarray, shape=(n, n)
             Linearized autonomous dynamics about (x, u).
         """
-        dyn_jnp = lambda x, u: self.dyn(0, x, u)
+        dyn_jnp = lambda x, u: self.dyn(t, x, u)
         _A = jacobian(dyn_jnp, argnums=0)(x, u)
         return _A
 
+    @property
     @partial(jit, static_argnums=(0,))
     def B(self, t: float, x: np.ndarray, u: np.ndarray) -> np.ndarray:
         """Linearized control dynamics about (x, u).
@@ -92,7 +93,7 @@ class System(ABC):
         _B : np.ndarray, shape=(n, m)
             Linearized control dynamics about (x, u).
         """
-        dyn_jnp = lambda x, u: self.dyn(0, x, u)
+        dyn_jnp = lambda x, u: self.dyn(t, x, u)
         _B = jacobian(dyn_jnp, argnums=1)(x, u)
         return _B
 

--- a/dyn_sim/util/jax_utils.py
+++ b/dyn_sim/util/jax_utils.py
@@ -7,9 +7,10 @@ from jax import jit
 def jax_func(func):
     @wraps(func)
     def wrapper(*args, np_out: bool = True, **kwargs):
+        result = jit(func, static_argnums=(0,))(*args, **kwargs)
         if np_out:
-            return np.array(jit(func, static_argnums=(0,))(*args, **kwargs))
+            return np.array(result)
         else:
-            return jit(func, static_argnums=(0,))(*args, **kwargs)
+            return result
 
     return wrapper

--- a/dyn_sim/util/jax_utils.py
+++ b/dyn_sim/util/jax_utils.py
@@ -8,7 +8,11 @@ TFunc = Callable[..., Any]
 
 
 def jax_func(func: TFunc) -> TFunc:
-    """Decorator for internal jax functions for System objects.
+    """Decorator for internal jax functions (any func needing auto diff).
+
+    Does two things:
+    (1) Assumes that the jax func is an object method so the first argument is self. The function is jit'd but we treat self as a static argument and only autodiff through the other args.
+    (2) Adds an np_out flag to the jax function (for convenience). The flag is set to True by default. If True, then the output of the function is cast to a numpy array. If False, then the output is passed as a jnp array. The purpose is so that if the end user calls jax functions outside of a context where they need AD, they won't be confused by jax errors resulting from incompatibility between jnp and np arrays (ex: if you are interfacing with gurobi). The burden to remember to be explicit about the outputs being jnp arrays falls to the designer, who must remember to pass np_out=False.
 
     Parameters
     ----------
@@ -20,7 +24,7 @@ def jax_func(func: TFunc) -> TFunc:
     class ExampleSystem(System):
 
         @jax_func
-        def example_func(self, *args, **kwargs) -> TYPE:
+        def example_func(self, *args, **kwargs) -> jnp.ndarray:
             ...
             return result
 

--- a/dyn_sim/util/jax_utils.py
+++ b/dyn_sim/util/jax_utils.py
@@ -1,12 +1,38 @@
 from functools import wraps
+from typing import Any, Callable
 
 import numpy as np
 from jax import jit
 
+TFunc = Callable[..., Any]
 
-def jax_func(func):
+
+def jax_func(func: TFunc) -> TFunc:
+    """Decorator for internal jax functions for System objects.
+
+    Parameters
+    ----------
+    func : TFunc
+        The function to be wrapped.
+
+    Usage
+    -----
+    class ExampleSystem(System):
+
+        @jax_func
+        def example_func(self, *args, **kwargs) -> TYPE:
+            ...
+            return result
+
+    # internal usage when AD is needed
+    result = example_func(..., np_out=False)
+
+    # external usage when we need a np array (like passing to gurobi)
+    result = example_func(...)
+    """
+
     @wraps(func)
-    def wrapper(*args, np_out: bool = True, **kwargs):
+    def wrapper(*args, np_out: bool = True, **kwargs) -> Any:
         result = jit(func, static_argnums=(0,))(*args, **kwargs)
         if np_out:
             return np.array(result)

--- a/dyn_sim/util/jax_utils.py
+++ b/dyn_sim/util/jax_utils.py
@@ -1,0 +1,15 @@
+from functools import wraps
+
+import numpy as np
+from jax import jit
+
+
+def jax_func(func):
+    @wraps(func)
+    def wrapper(*args, np_out: bool = True, **kwargs):
+        if np_out:
+            return np.array(jit(func, static_argnums=(0,))(*args, **kwargs))
+        else:
+            return jit(func, static_argnums=(0,))(*args, **kwargs)
+
+    return wrapper

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,8 @@ flake8==3.9.2
 flake8-docstrings==1.6.0
 gurobipy==9.5.0
 isort==5.10.1
+jax==0.3.13
+jaxlib==0.3.10
 kiwisolver==1.4.2
 matplotlib==3.5.2
 mypy==0.950

--- a/scripts/planar/segway/ex_slmpc_segway.py
+++ b/scripts/planar/segway/ex_slmpc_segway.py
@@ -2,6 +2,7 @@ import sys
 from typing import Union
 
 import gurobipy as gp
+import matplotlib.pyplot as plt
 import numpy as np
 
 sys.path.append("..")
@@ -59,12 +60,12 @@ def x_ref(t: float, x: np.ndarray, slmpc: SLMPC) -> Union[np.ndarray, gp.MVar]:
         State reference at time t.
     """
     _ref = np.zeros(4)
-    # amp = 1
-    # coeff = 0.1
-    # _ref[0] = amp * np.sin(coeff * t)
-    # _ref[2] = coeff * amp * np.cos(coeff * t)
-    _ref[0] = t / 30.0
-    _ref[2] = 1 / 30.0
+    amp = 1
+    coeff = 1
+    _ref[0] = amp * np.sin(coeff * t)
+    _ref[2] = coeff * amp * np.cos(coeff * t)
+    # _ref[0] = t / 30.0
+    # _ref[2] = 1 / 30.0
     return _ref
 
 
@@ -129,6 +130,21 @@ if __name__ == "__main__":
     n_frames = int(10 * sim_length + 1)  # number of frames
     tsim = np.linspace(0, sim_length, n_frames)  # query times
     t_sol, x_sol = simulator.simulate(x0, tsim)
+
+    # summary plot
+    fig = plt.Figure()
+    plt.plot(t_sol, x_sol[0, :], label="MPC Path")
+    ref_vals = np.zeros(x_sol.shape)
+    for i in range(len(t_sol)):
+        ti = t_sol[i]
+        xi = x_sol[:, i]
+        ref_vals[:, i] = x_ref(ti, xi, slmpc)
+    plt.plot(t_sol, ref_vals[0, :], label="Reference Path")
+    plt.title("MPC: Linearization About IC")
+    plt.xlabel("Time (s)")
+    plt.ylabel("Planar Position (m)")
+    plt.legend()
+    plt.show()
 
     # animating the solution
     fps = 20.0  # animation fps

--- a/scripts/spatial/quad/ex_slmpc_quad.py
+++ b/scripts/spatial/quad/ex_slmpc_quad.py
@@ -37,7 +37,7 @@ mpc_P = np.diag([12, 12, 12, 1, 1, 1, 2, 2, 2, 1, 1, 1])  # LQ cost weights
 mpc_Q = mpc_P
 mpc_R = np.diag([0.01, 0.01, 0.01, 0.01])
 mpc_h = None
-v_safe = 0.75  # safe velocity (m/s)
+v_safe = None  # safe velocity (m/s)
 ang_safe = 0.5  # safe angular tilt (rad)
 print_t = True  # [DEBUG] prints computation times
 

--- a/scripts/spatial/quad/ex_slmpc_quad.py
+++ b/scripts/spatial/quad/ex_slmpc_quad.py
@@ -37,7 +37,7 @@ mpc_P = np.diag([12, 12, 12, 1, 1, 1, 2, 2, 2, 1, 1, 1])  # LQ cost weights
 mpc_Q = mpc_P
 mpc_R = np.diag([0.01, 0.01, 0.01, 0.01])
 mpc_h = None
-v_safe = None  # safe velocity (m/s)
+v_safe = 0.75  # safe velocity (m/s)
 ang_safe = 0.5  # safe angular tilt (rad)
 print_t = True  # [DEBUG] prints computation times
 


### PR DESCRIPTION
The purpose of this PR is to make dynamics jax-compatible so that gradients can be computed automatically. This will also set up usage for iLQR and neural-network parameterized systems in future development.

Checklist

- [x] Updated `requirements.txt`
- [x] Made `sys_core.py` Jax-friendly by automating the computation of A and B.
- [x] Converted `quad.py` to be Jax-friendly
- [x] Converted `segway.py` to be Jax-friendly
- [x] Converted `mpc.py` to be Jax-friendly by converting Jax objects to numpy objects before passing to Gurobi
- [x] Converted `slmpc_quad_ctrl.py` to be Jax-friendly by converting Jax objects to numpy objects before passing to Gurobi
- [x] Change docstrings in relevant files to reflect jnp objects instead of np objects
- [x] Make decorator function for automatically passing jnp outputs as np, then only when AD is needed, activate jnp outputs
- [x] Add jit decorator on all jnp-output functions, possibly combine this decorator with the above decorator
- [x] Update README to explain jax integration